### PR TITLE
#3 allow null for fields without default value

### DIFF
--- a/db/migrate/20170827111550_add_timestamps_to_custom_entity.rb
+++ b/db/migrate/20170827111550_add_timestamps_to_custom_entity.rb
@@ -1,6 +1,6 @@
 class AddTimestampsToCustomEntity < ActiveRecord::Migration[4.2]
   def change
-    add_column :custom_entities, :created_at, :datetime, null: false
-    add_column :custom_entities, :updated_at, :datetime, null: false
+    add_column :custom_entities, :created_at, :datetime, null: true
+    add_column :custom_entities, :updated_at, :datetime, null: true
   end
 end

--- a/db/migrate/20170909171338_add_subtables_to_custom_tables.rb
+++ b/db/migrate/20170909171338_add_subtables_to_custom_tables.rb
@@ -1,8 +1,8 @@
 class AddSubtablesToCustomTables < ActiveRecord::Migration[4.2]
   def change
     add_column :custom_tables, :parent_id, :integer, null: true, :index => true
-    add_column :custom_tables, :lft, :integer, null: false, :index => true
-    add_column :custom_tables, :rgt, :integer, null: false, :index => true
+    add_column :custom_tables, :lft, :integer, null: true, :index => true
+    add_column :custom_tables, :rgt, :integer, null: true, :index => true
 
     add_column :custom_tables, :depth, :integer, null: false, default: 0
     add_column :custom_tables, :children_count, :integer, null: false, default: 0


### PR DESCRIPTION
Sqlite does not allow to add not-null fields without default value. One can either set a default or allow null on these fields. Allowing null should work for all supported DBs