### PR TITLE
REDMINE 6 custom_tables plugin upgrade 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.DS_Store
+.eslintcache
+.rvmrc
+.project
+.idea

--- a/app/helpers/custom_tables_helper.rb
+++ b/app/helpers/custom_tables_helper.rb
@@ -12,6 +12,14 @@ module CustomTablesHelper
     end
   end
 
+  def sprite_icon(icon_name, label = nil, icon_only: false, size: 0, css_class: nil, sprite: 0, plugin: nil, rtl: false)
+    if label
+      label
+    else
+      ''
+    end
+  end
+
   def render_custom_table_content(column, entity)
     value = column.value_object(entity)
     if value.is_a?(Array)

--- a/app/helpers/custom_tables_helper.rb
+++ b/app/helpers/custom_tables_helper.rb
@@ -12,14 +12,6 @@ module CustomTablesHelper
     end
   end
 
-  def sprite_icon(icon_name, label = nil, icon_only: false, size: 0, css_class: nil, sprite: 0, plugin: nil, rtl: false)
-    if label
-      label
-    else
-      ''
-    end
-  end
-
   def render_custom_table_content(column, entity)
     value = column.value_object(entity)
     if value.is_a?(Array)

--- a/app/models/custom_entity.rb
+++ b/app/models/custom_entity.rb
@@ -1,4 +1,4 @@
-class CustomEntity < ActiveRecord::Base
+class CustomEntity < CustomTables::ActiveRecordClass.base
   include Redmine::SafeAttributes
   include CustomTables::ActsAsJournalize
 

--- a/app/models/custom_entity_query.rb
+++ b/app/models/custom_entity_query.rb
@@ -29,7 +29,15 @@ class CustomEntityQuery < Query
     add_available_filter "updated_at", type: :date, label: :field_updated_on
     add_available_filter "author_id", type: :list, values: lambda { author_values }
 
-    CustomEntityCustomField.visible.where(is_filter: true, custom_table_id: custom_table_id).sorted.each do |field|
+    visible_custom_fields = CustomEntityCustomField.visible.where(is_filter: true)
+
+    if custom_table_id
+      # when requesting available values for custom field there is no custom_table_id
+      # so we don't need to overwrite action QueriesController#filters
+      visible_custom_fields = visible_custom_fields.where(custom_table_id: custom_table_id).sorted
+    end
+
+    visible_custom_fields.each do |field|
       add_custom_field_filter(field)
     end
   end
@@ -83,5 +91,9 @@ class CustomEntityQuery < Query
     when "*"
       "#{CustomEntity.table_name}.issue_id IS NOT NULL"
     end
+  end
+
+  def users
+    User.active
   end
 end

--- a/app/models/custom_table.rb
+++ b/app/models/custom_table.rb
@@ -1,4 +1,4 @@
-class CustomTable < ActiveRecord::Base
+class CustomTable < CustomTables::ActiveRecordClass.base
   include Redmine::SafeAttributes
 
   belongs_to :author, class_name: 'User', foreign_key: 'author_id'

--- a/app/views/custom_entities/context_menu.html.erb
+++ b/app/views/custom_entities/context_menu.html.erb
@@ -2,11 +2,12 @@
 <ul>
   <% if @custom_entity %>
     <% if User.current.admin? %>
-      <li><%= context_menu_link l(:button_show), custom_entity_path(@custom_entity), class: 'icon-show' %></li>
+      <li><%= context_menu_link sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(@custom_entity), class: 'icon icon-arrow-right' %></li>
     <% end %>
-      <li><%= context_menu_link l(:button_edit), edit_custom_entity_path(@custom_entity, edit_query: true, back_url: params[:back_url]), remote: true, class: 'icon icon-edit', disabled: !@can[:edit] %></li>
+    <li><%= context_menu_link sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(@custom_entity, edit_query: true, back_url: params[:back_url]),
+                              remote: true, class: 'icon icon-edit', disabled: !@can[:edit] %></li>
   <% else %>
-      <li><%= context_menu_link l(:button_edit), bulk_edit_custom_entities_path(ids: @custom_entity_ids, back_url: @back), remote: true, class: 'icon icon-edit' %></li>
+      <li><%= context_menu_link sprite_icon('edit', l(:button_edit)), bulk_edit_custom_entities_path(ids: @custom_entity_ids, back_url: @back), remote: true, class: 'icon icon-edit' %></li>
   <% end %>
   <li class="folder">
     <a href="#" class="submenu"><%= l(:field_export) %></a>
@@ -16,5 +17,5 @@
       <%= call_hook(:view_context_menu_custom_entities_export, { ids: @custom_entity_ids, back_url: @back, params: params, class_name: class_name }) %>
     </ul>
   </li>
-  <li><%= context_menu_link l(:button_delete), custom_entities_path(ids: @custom_entity_ids, back_url: @back), method: :delete, data: {confirm: l(:text_are_you_sure)}, class: 'icon icon-del', disabled: !@can[:delete] %></li>
+  <li><%= context_menu_link sprite_icon('del', l(:button_delete)), custom_entities_path(ids: @custom_entity_ids, back_url: @back), method: :delete, data: {confirm: l(:text_are_you_sure)}, class: 'icon icon-del', disabled: !@can[:delete] %></li>
 </ul>

--- a/app/views/custom_entities/context_menu.html.erb
+++ b/app/views/custom_entities/context_menu.html.erb
@@ -2,7 +2,7 @@
 <ul>
   <% if @custom_entity %>
     <% if User.current.admin? %>
-      <li><%= context_menu_link sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(@custom_entity), class: 'icon icon-arrow-right' %></li>
+      <li><%= context_menu_link sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(@custom_entity), class: Redmine::VERSION::MAJOR > 5 ? 'icon' : 'icon icon-arrow-right' %></li>
     <% end %>
     <li><%= context_menu_link sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(@custom_entity, edit_query: true, back_url: params[:back_url]),
                               remote: true, class: 'icon icon-edit', disabled: !@can[:edit] %></li>

--- a/app/views/custom_entities/show.html.erb
+++ b/app/views/custom_entities/show.html.erb
@@ -1,8 +1,8 @@
 <div class="contextual">
   <%= call_hook(:view_custom_table_table_field_action_menu) %>
-  <%= link_to l(:button_edit), edit_custom_entity_path(@custom_entity, back_url: custom_entity_path(@custom_entity)), remote: true, class: 'icon icon-edit' %>
-  <%= link_to l(:button_new_comment), new_note_custom_entity_path(@custom_entity), remote: true, class: 'icon icon-issue-edit' %>
-  <%= link_to l(:button_delete), custom_entity_path(@custom_entity, custom_table_id: @custom_entity.custom_table), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon icon-del' %>
+  <%= link_to sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(@custom_entity, back_url: custom_entity_path(@custom_entity)), remote: true, class: 'icon icon-edit' %>
+  <%= link_to sprite_icon('issue-edit',l(:button_new_comment)), new_note_custom_entity_path(@custom_entity), remote: true, class: 'icon icon-issue-edit' %>
+  <%= link_to sprite_icon('del', l(:button_delete)), custom_entity_path(@custom_entity, custom_table_id: @custom_entity.custom_table), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon icon-del' %>
 </div>
 
 <%= title [l(:label_custom_tables), custom_tables_path],

--- a/app/views/custom_tables/_query_form.html.erb
+++ b/app/views/custom_tables/_query_form.html.erb
@@ -42,7 +42,7 @@
               <td class="checkbox hide-when-print"><%= check_box_tag("ids[]", entity.id, false, id: nil) %></td>
               <%= raw query.inline_columns.map {|column| "<td class=\"#{column.css_classes}\">#{column_content(column, entity)}</td>"}.join %>
               <td class="buttons">
-                    <%= link_to sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(entity), title: l(:label_open_issues), class: 'icon-only icon-arrow-right' %>
+                    <%= link_to sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(entity), title: l(:label_open_issues), class: Redmine::VERSION::MAJOR > 5 ? 'icon-only' : 'icon-only icon-arrow-right' %>
                     <%= link_to sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>
                     <%= link_to sprite_icon('del', l(:button_delete)), custom_entity_path(entity, custom_table_id: @custom_table, project_id: params[:project_id], back_url: back_url), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
               </td>

--- a/app/views/custom_tables/_query_form.html.erb
+++ b/app/views/custom_tables/_query_form.html.erb
@@ -42,9 +42,9 @@
               <td class="checkbox hide-when-print"><%= check_box_tag("ids[]", entity.id, false, id: nil) %></td>
               <%= raw query.inline_columns.map {|column| "<td class=\"#{column.css_classes}\">#{column_content(column, entity)}</td>"}.join %>
               <td class="buttons">
-                    <%= link_to l(:button_show), custom_entity_path(entity), title: l(:button_show), class: 'icon-only icon-magnifier' %>
-                    <%= link_to l(:button_edit), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>
-                    <%= link_to l(:button_delete), custom_entity_path(entity, custom_table_id: @custom_table, project_id: params[:project_id], back_url: back_url), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
+                    <%= link_to sprite_icon('bullet-go', l(:label_open_issues)), custom_entity_path(entity), title: l(:label_open_issues), class: 'icon-only icon-arrow-right' %>
+                    <%= link_to sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>
+                    <%= link_to sprite_icon('del', l(:button_delete)), custom_entity_path(entity, custom_table_id: @custom_table, project_id: params[:project_id], back_url: back_url), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
               </td>
             </tr>
         <% end %>

--- a/app/views/custom_tables/_query_headers.html.erb
+++ b/app/views/custom_tables/_query_headers.html.erb
@@ -42,8 +42,8 @@
     </fieldset>
   </div>
   <p class="buttons">
-    <%= link_to_function l(:button_apply), '$("#query_form").submit()', :class => 'icon icon-checked' %>
-    <%= link_to l(:button_clear), { :set_filter => 1, :sort => '', :project_id => @project }, :class => 'icon icon-reload'  %>
+    <%= link_to_function sprite_icon('checked', l(:button_apply)), '$("#query_form").submit()', :class => 'icon icon-checked' %>
+    <%= link_to sprite_icon('reload', l(:button_clear)), { :set_filter => 1, :sort => '', :project_id => @project }, :class => 'icon icon-reload'  %>
     <%= form_tag({}, method: :get) do %>
       <%= text_field_tag 'name_like', params[:name_like], size: 30 %>
       <%= submit_tag l(:label_search), class: "small", name_like: nil %>

--- a/app/views/custom_tables/index.html.erb
+++ b/app/views/custom_tables/index.html.erb
@@ -1,5 +1,5 @@
 <div class="contextual">
-  <%= link_to l(:label_custom_table_new), new_custom_table_path, remote: true, class: 'icon icon-add' %>
+  <%= link_to sprite_icon('add', l(:label_custom_table_new)), new_custom_table_path, remote: true, class: 'icon icon-add' %>
 </div>
 
 <%= title l(:label_glad_custom_tables) %>
@@ -9,7 +9,7 @@
     <%= text_field_tag 'name_like', params[:name_like], size: 30 %>
     <%= submit_tag l(:button_apply), class: "small", name_like: nil %>
   <% end %>
-  <%= link_to l(:button_clear), custom_tables_path, :class => 'icon icon-reload' %>
+  <%= link_to sprite_icon('reload', l(:button_clear)), custom_tables_path, :class => 'icon icon-reload' %>
 </fieldset>
 <br>
 
@@ -29,8 +29,8 @@
       <tr class="<%= table.css_classes %> <%= level > 0 ? "idnt idnt-#{level}" : nil %> ">
         <%= raw @query.inline_columns.map {|column| "<td class=\"#{column.css_classes}\"><span> #{render_custom_table_content(column, table)}</span></td>"}.join %>
         <td class="buttons">
-          <%= link_to l(:button_edit), edit_custom_table_path(table), title: l(:label_settings), class: 'icon-only icon-settings' %>
-          <%= link_to l(:button_delete), custom_table_path(table, back_url: custom_tables_path), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
+          <%= link_to sprite_icon('settings', l(:button_edit)), edit_custom_table_path(table), title: l(:label_settings), class: 'icon-only icon-settings' %>
+          <%= link_to sprite_icon('del', l(:button_delete)), custom_table_path(table, back_url: custom_tables_path), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
         </td>
       </tr>
     <% end -%>

--- a/app/views/custom_tables/show.html.erb
+++ b/app/views/custom_tables/show.html.erb
@@ -1,7 +1,7 @@
 <div class="contextual">
-  <%= link_to l(:label_settings), edit_custom_table_path(@custom_table), class: 'icon icon-settings' %>
-  <%= link_to l(:label_new_column), new_table_field_path(custom_table_id: @custom_table), remote: true, class: 'icon icon-custom-fields' %>
-  <%= link_to l(:label_new), new_custom_entity_path(custom_table_id: @custom_table), remote: true, class: 'icon icon-add' %>
+  <%= link_to sprite_icon('settings', l(:label_settings)), edit_custom_table_path(@custom_table), class: 'icon icon-settings' %>
+  <%= link_to sprite_icon('custom-fields', l(:label_new_column)), new_table_field_path(custom_table_id: @custom_table), remote: true, class: 'icon icon-custom-fields' %>
+  <%= link_to sprite_icon('add', l(:label_new)), new_custom_entity_path(custom_table_id: @custom_table), remote: true, class: 'icon icon-add' %>
 </div>
 
 <%= title [l(:label_custom_tables), custom_tables_path], @custom_table.name %>

--- a/app/views/issues/_query_custom_table.html.erb
+++ b/app/views/issues/_query_custom_table.html.erb
@@ -22,7 +22,7 @@
           <%= raw query.inline_columns.map {|column| "<td class=\"#{column.css_classes}\">#{column_content(column, entity)}</td>"}.join %>
           <td class="buttons">
             <% if User.current.admin? %>
-              <%= link_to sprite_icon('bullet-go', l(:button_show)), custom_entity_path(entity), title: l(:button_show), class: 'icon-only icon-arrow-right' %>
+              <%= link_to sprite_icon('bullet-go', l(:button_show)), custom_entity_path(entity), title: l(:button_show), class: Redmine::VERSION::MAJOR > 5 ? 'icon-only' : 'icon-only icon-arrow-right' %>
             <% end %>
             <% if User.current.allowed_to?(:manage_custom_tables, nil, global: true) %>
               <%= link_to sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>

--- a/app/views/issues/_query_custom_table.html.erb
+++ b/app/views/issues/_query_custom_table.html.erb
@@ -22,11 +22,11 @@
           <%= raw query.inline_columns.map {|column| "<td class=\"#{column.css_classes}\">#{column_content(column, entity)}</td>"}.join %>
           <td class="buttons">
             <% if User.current.admin? %>
-              <%= link_to l(:button_show), custom_entity_path(entity), title: l(:button_show), class: 'icon-only icon-magnifier' %>
+              <%= link_to sprite_icon('bullet-go', l(:button_show)), custom_entity_path(entity), title: l(:button_show), class: 'icon-only icon-arrow-right' %>
             <% end %>
             <% if User.current.allowed_to?(:manage_custom_tables, nil, global: true) %>
-              <%= link_to l(:button_edit), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>
-              <%= link_to l(:button_delete), custom_entity_path(entity, custom_table_id: custom_table, back_url: back_url), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
+              <%= link_to sprite_icon('edit', l(:button_edit)), edit_custom_entity_path(entity, edit_query: true, back_url: back_url), remote: true, title: l(:button_edit), class: 'icon-only icon-edit' %>
+              <%= link_to sprite_icon('del', l(:button_delete)), custom_entity_path(entity, custom_table_id: custom_table, back_url: back_url), data: {confirm: l(:text_are_you_sure)}, method: :delete, title: l(:button_delete), class: 'icon-only icon-del' %>
             <% end %>
           </td>
         </tr>

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :custom_tables do
   name 'Custom Tables plugin'
   author 'Ivan Marangoz'
   description 'This is a plugin for Redmine'
-  version '1.0.7'
+  version '1.1.0'
   requires_redmine :version_or_higher => '3.4.0'
   url 'https://github.com/frywer/custom_tables'
   author_url 'https://github.com/frywer'

--- a/init.rb
+++ b/init.rb
@@ -20,7 +20,7 @@ end
 
 Redmine::MenuManager.map :admin_menu do |menu|
   menu.push :custom_tables, :custom_tables_path, caption: :label_custom_tables,
-            :html => {:class => 'icon icon-package'}
+            :html => {:class => Redmine::VERSION::MAJOR > 5 ? 'icon' : 'icon icon-package'}
 end
 
 Dir[File.join(File.dirname(__FILE__), '/lib/custom_tables/**/*.rb')].each { |file| require_dependency file }

--- a/lib/custom_tables/active_record_class.rb
+++ b/lib/custom_tables/active_record_class.rb
@@ -1,0 +1,11 @@
+module CustomTables
+  class ActiveRecordClass
+    def self.base
+      if Redmine::VERSION::MAJOR > 5
+        ApplicationRecord
+      else
+        ActiveRecord::Base
+      end
+    end
+  end
+end

--- a/lib/custom_tables/patches/application_helper_patch.rb
+++ b/lib/custom_tables/patches/application_helper_patch.rb
@@ -1,0 +1,23 @@
+module CustomTables
+  module Patches
+    module ApplicationHelperPatch
+      def self.included(base)
+        base.class_eval do
+
+          # define sprite_icon for redmine 5 and ignore for redmine 6
+          unless self.method_defined?(:sprite_icon)
+            def sprite_icon(icon_name, label = nil, icon_only: false, size: 0, css_class: nil, sprite: 0, plugin: nil, rtl: false)
+              if label
+                label
+              else
+                ''
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ApplicationHelper.send(:include, CustomTables::Patches::ApplicationHelperPatch)

--- a/lib/custom_tables/patches/lib/issue_pdf_helper_patch.rb
+++ b/lib/custom_tables/patches/lib/issue_pdf_helper_patch.rb
@@ -1,0 +1,56 @@
+module CustomTables
+  module Patches
+    module Lib
+      module IssuePdfHelperPatch
+        def self.included(base)
+          base.class_eval do
+
+            def pdf_format_text(object, attribute)
+              text = textilizable(object, attribute,
+                           :only_path => false,
+                           :edit_section_links => false,
+                           :headings => false,
+                           :inline_attachments => false
+              )
+              if object.is_a?(Issue) && attribute == :description
+                return text.to_s + textilizable(custom_tables_html(object).join)
+              end
+              return text
+            end
+
+            def custom_tables_html(issue)
+              custom_tables = []
+              issue.project.all_issue_custom_tables(issue).each do |custom_table|
+                query = custom_table.query(totalable_all: true)
+                query.add_short_filter('issue_id', "=#{issue.id}")
+                result_scope = query.results_scope
+                next if result_scope.empty?
+                html_table = '<hr/><strong>' + custom_table.name + '</strong><br>'
+                html_table += '<table><tr>'
+
+                html_table += query.columns.map {|column| "<td><strong>" + column.custom_field.name + "</strong></td>"}.join
+                html_table += "</tr>"
+                result_scope.each do |custom_entity|
+                  html_table += "<tr>"
+                  custom_field_values = custom_entity.visible_custom_field_values
+                  custom_field_values.each do |value|
+                    text = show_value(value, false)
+                    next if text.blank?
+                    html_table += "<td>" + text + "</td>"
+                  end
+                  html_table += "</tr>"
+                end
+                html_table += "</table>"
+
+                custom_tables << html_table
+              end
+              return custom_tables
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Redmine::Export::PDF::IssuesPdfHelper.send(:include, CustomTables::Patches::Lib::IssuePdfHelperPatch)

--- a/lib/custom_tables/patches/user_format_patch.rb
+++ b/lib/custom_tables/patches/user_format_patch.rb
@@ -1,0 +1,15 @@
+module CustomTables
+  module Patches
+    module UserFormatPatch
+      def possible_values_records(custom_field, object=nil)
+        if custom_field.is_a? CustomEntityCustomField
+          User.active
+        else
+          super
+        end
+      end
+    end
+  end
+end
+
+Redmine::FieldFormat::UserFormat.send(:prepend, CustomTables::Patches::UserFormatPatch)

--- a/spec/models/custom_entity_custom_field_spec.rb
+++ b/spec/models/custom_entity_custom_field_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe CustomEntityCustomField, type: :model do
+  let(:role) { FactoryBot.create(:role) }
+  let(:member) { FactoryBot.create(:member) }
+  let(:user) { FactoryBot.create(:user, memberships: [member]) }
+  let(:custom_table) { FactoryBot.create(:custom_table, custom_fields: [
+    { external_name: 'name', field_format: 'string'},
+    { external_name: 'age', field_format: 'int' },
+    { external_name: 'height', field_format: 'float' },
+    { external_name: 'user', field_format: 'user' }
+  ] ) }
+  let(:external_values) {
+    {
+      'name' => 'My name',
+      'age' => '21',
+      'height' => '140.5',
+      'user' => user.id
+    }
+  }
+
+  describe '#imported_values' do
+    let(:custom_entity) { CustomEntity.new(custom_table: custom_table, author: User.current) }
+
+    context 'when values are valid' do
+      it 'create custom_entity with external values' do
+        custom_entity.external_values = external_values
+
+        expect(custom_entity.to_h).to eq({'name' => 'My name',
+                                          'age' => '21',
+                                          'height' => '140.5',
+                                          'user' => user.id.to_s,
+                                          'id' => custom_entity.id })
+      end
+    end
+  end
+
+  describe '#visible?' do
+    let(:custom_entity) { FactoryBot.create(:custom_entity, custom_table: custom_table, external_values: external_values) }
+
+    subject { custom_entity.visible?(user) }
+
+    context 'with permission' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'without permission' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe 'FieldFormat' do
+    describe 'UserFormat' do
+      describe '#possible_values_records' do
+        let(:user_custom_field) { custom_table.custom_fields.find { |cf| cf.field_format == 'user' } }
+        let(:possible_values) { user_custom_field.format.possible_values_records(user_custom_field) }
+
+        it 'returns the user records' do
+          expect(possible_values).to eq(User.active)
+          expect(possible_values).to include(user)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/custom_entity_query_spec.rb
+++ b/spec/models/custom_entity_query_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe CustomEntityQuery, type: :model do
+  describe "#available_filters" do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:custom_entity_query) { described_class.new }
+    let!(:custom_table) { FactoryBot.create(:custom_table, custom_fields: [
+      { external_name: 'name', field_format: 'string'},
+      { external_name: 'age', field_format: 'int' },
+      { external_name: 'height', field_format: 'float' },
+      { external_name: 'user', field_format: 'user' }
+    ] ) }
+    let(:user_custom_field) { custom_table.custom_fields.find { |cf| cf.field_format == 'user' } }
+    let(:filter_options) { custom_entity_query.available_filters["cf_#{user_custom_field.id}"].values.flatten }
+
+    context "when custom_table_id is nil" do
+      before { custom_entity_query.initialize_available_filters }
+
+      it "returns the custom field" do
+        expect(filter_options).to include(user.id.to_s)
+      end
+    end
+
+    context "when custom_table_id is present" do
+      before do
+        custom_entity_query.custom_table_id = custom_table.id
+        custom_entity_query.initialize_available_filters
+      end
+
+      it "returns the custom field" do
+        expect(filter_options).to include(user.id.to_s)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
   config.default_path = 'plugins/custom_tables/spec'
-  config.fixture_path = "#{::Rails.root}/test/fixtures"
+  # config.fixture_path = "#{::Rails.root}/test/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.include AssertSelectRoot, :type => :request


### PR DESCRIPTION
* In Redmine 6, ActiveRecord::Base was replaced with ApplicationRecord, which is essential for ensuring plugin compatibility with the latest Redmine versions. Additionally, Redmine 6 introduces a new set of icons that may affect UI elements.
* This update also includes a fix for the user custom field dropdown, resolving issues with not showing users list in the dropdown
* That fix is compatible with Redmine 5 and Redmine 6