### PR TITLE
#51 convert project to a project name with .to_s when building a tree

### DIFF
--- a/app/views/custom_tables/_form.html.erb
+++ b/app/views/custom_tables/_form.html.erb
@@ -48,7 +48,7 @@
     <div id="custom_field_project_ids">
       <% project_ids = @custom_table.project_ids.to_a %>
       <%= render_project_nested_lists(Project.all) do |p|
-        content_tag('label', check_box_tag('custom_table[project_ids][]', p.id, project_ids.include?(p.id), :id => nil, class: 'custom_table_project_checkbox', disabled: f.object.is_for_all) + ' ' + p)
+        content_tag('label', check_box_tag('custom_table[project_ids][]', p.id, project_ids.include?(p.id), :id => nil, class: 'custom_table_project_checkbox', disabled: f.object.is_for_all) + ' ' + p.to_s)
       end %>
       <%= hidden_field_tag('custom_table[project_ids][]', '', :id => nil) %>
     </div>

--- a/app/views/table_fields/_form.html.erb
+++ b/app/views/table_fields/_form.html.erb
@@ -105,7 +105,7 @@ when "IssueCustomField" %>
   <fieldset class="box" id="custom_field_project_ids"><legend><%= l(:label_project_plural) %></legend>
     <% project_ids = @custom_field.project_ids.to_a %>
     <%= render_project_nested_lists(Project.all) do |p|
-      content_tag('label', check_box_tag('custom_field[project_ids][]', p.id, project_ids.include?(p.id), :id => nil) + ' ' + p)
+      content_tag('label', check_box_tag('custom_field[project_ids][]', p.id, project_ids.include?(p.id), :id => nil) + ' ' + p.to_s)
     end %>
     <%= hidden_field_tag('custom_field[project_ids][]', '', :id => nil) %>
     <p><%= check_all_links 'custom_field_project_ids' %></p>

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,0 +1,30 @@
+sv:
+  # my_label: "Min rubrik"
+  label_id: ID
+  label_custom_tables: Custom tables
+  label_glad_custom_tables: Anpassade tabeller
+  label_custom_table_new: Ny tabell
+  label_custom_table: Anpassad tabell
+  label_table: Tabell
+  label_custom_table_edit: Redigera tabell
+  glad_custom_tables: Anpassade tabeller
+  custom_tables: Anpassade tabeller
+  label_custom_entity_edit: Redigera %{name}
+  label_custom_entity_new: Ny %{name}
+  label_custom_table_tab: '%{name}'
+  button_edit_custom_table: Redigera tabell
+  button_delete_custom_table: Ta bort tabell
+  label_custom_field_edit: Redigera anpassat fält
+  field_main_custom_field: Huvudkolumn
+  label_belongs_to: Tillhör
+  field_parent_table: Tabell
+  label_bulk_edit_selected: Massredigera valda %{table_name}
+  label_new_column: Ny kolumn
+  label_all_tables: Alla tabeller
+  help_please_configure_table_first: Det finns inte några anpassade fält i denna tabell. %{settings}
+  label_add: Lägg till
+  button_new_comment: Ny kommentar
+  label_new_note: Ny kommentar
+  field_external_name: Externt namn
+  field_export: Exportera
+  text_missing_permission_manage_custom_tables: Du har ej rättigheter att ändra anpassade tabeller!

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :custom_tables do
   name 'Custom Tables plugin'
   author 'Ivan Marangoz'
   description 'This is a plugin for Redmine'
-  version '1.1.0'
+  version '1.1.1'
   requires_redmine :version_or_higher => '3.4.0'
   url 'https://github.com/frywer/custom_tables'
   author_url 'https://github.com/frywer'


### PR DESCRIPTION
In redmine 6 when comparing project instance with a string it uses invalid method `to_str` instead of the `to_s` which converts project to it's name